### PR TITLE
Fixed the issue #10: team name instead of many authors in the footer

### DIFF
--- a/report.typ
+++ b/report.typ
@@ -89,3 +89,4 @@
   [blablabla], [blebleble], [blublubluuu],
   [blablabla], [blebleble], [blublubluuu],
 )
+

--- a/uc3mreport.typ
+++ b/uc3mreport.typ
@@ -80,9 +80,9 @@
   v(1fr) 
 
   // team
-  if team != none [
-    #team
-  ]
+  if team != none {
+    text(size: 1.4em, team)
+  }
 
   // authors
   if authors.len() < 5 {
@@ -99,7 +99,7 @@
       let slice = authors.slice(i * 3, end)
       grid(
         columns: slice.len() * (1fr,),
-        gutter: 12pt,
+        gutter: 10pt,
         ..slice.map(author => align(center, {
           set text(size: 11pt)
           author.name + " " + author.surname
@@ -303,9 +303,9 @@
       #set text(azuluc3m)
       #if authors.len() < 5 { 
         shortauthors(authors: authors)
-      } else {
-        if language == "es" { [Equipo #team] } else { [Team #team] }
-      }
+      } else [
+        #team
+      ]
       #h(1fr)
       #let page_delimeter = "of"
       #if language == "es" {


### PR DESCRIPTION
Also refactored the way they look in the cover in order to better fit them.

Closses #10 

The footer now looks like this:

<img width="687" height="90" alt="image" src="https://github.com/user-attachments/assets/80fe73ea-437a-409c-b5b4-3622d2a2d9c8" />

And the cover now looks like:

<img width="698" height="991" alt="image" src="https://github.com/user-attachments/assets/ed3043d7-95d2-40ef-997c-fac6f89f1b2f" />
