### PR TITLE
fix page heading formatting

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -295,7 +295,7 @@
       #set text(azuluc3m)
       #project
       #h(1fr)
-      #subject #if group != none [, grp. #group]
+      #subject#if group != none [, grp. #group]
 
       #v(-0.7em)
       #line(length: 100%, stroke: 0.4pt + azuluc3m)


### PR DESCRIPTION
Removes an extra space before the comma for the group in the page header.

Before:
<img width="571" height="41" alt="image" src="https://github.com/user-attachments/assets/dd87da75-7274-49f4-9598-33ed939297ff" />

After:
<img width="556" height="53" alt="image" src="https://github.com/user-attachments/assets/649376c4-72f1-4e2b-90fa-417a589e5169" />
